### PR TITLE
帳本成員改為僅儲存使用者ID，不儲存使用者實際資訊

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -25,7 +25,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/vincent/acnt/BookMemberActivity.java
+++ b/app/src/main/java/com/vincent/acnt/BookMemberActivity.java
@@ -1,37 +1,54 @@
 package com.vincent.acnt;
 
+import android.app.Dialog;
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.support.design.widget.TabLayout;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
+import android.widget.Toast;
 
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.EventListener;
 import com.google.firebase.firestore.FirebaseFirestoreException;
 import com.google.firebase.firestore.ListenerRegistration;
+import com.google.firebase.firestore.QuerySnapshot;
 import com.vincent.acnt.adapter.MemberPagerAdapter;
 import com.vincent.acnt.data.Constant;
+import com.vincent.acnt.data.Utility;
 import com.vincent.acnt.entity.Book;
 import com.vincent.acnt.entity.User;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
 public class BookMemberActivity extends AppCompatActivity {
     private Context context;
-    private Toolbar toolbar;
     private String activityTitle = "成員";
 
     private ViewPager vpgMember;
 
-    private BookMemberFragment[] memberFragments;
+    private BookMemberFragment[] memberFragments = new BookMemberFragment[2];
     private MemberPagerAdapter adapter;
 
+    private Set<String> userIds = new HashSet<>();
+    private List<User> legalMembers = new ArrayList<>(), waitingMembers = new ArrayList<>();
+
     private boolean isFirstIn = true;
+
+    private Dialog dlgWaiting;
+
+    private CollectionReference ref;
     private ListenerRegistration lsrBook;
 
     @Override
@@ -74,46 +91,107 @@ public class BookMemberActivity extends AppCompatActivity {
 
         tabHome.setupWithViewPager(vpgMember);
 
-        loadMembers();
-    }
-
-    private void loadMembers() {
         adapter = new MemberPagerAdapter(getSupportFragmentManager());
-        memberFragments = new BookMemberFragment[2];
         memberFragments[0] = new BookMemberFragment();
         memberFragments[1] = new BookMemberFragment();
         memberFragments[0].setType(Constant.CODE_APPROVED);
         memberFragments[1].setType(Constant.CODE_WAITING);
 
-        lsrBook= MyApp.db.collection(Constant.KEY_BOOKS).document(MyApp.browsingBook.obtainDocumentId())
+        dlgWaiting = Utility.getWaitingDialog(context);
+
+        try {
+            loadMembers();
+        } catch (Exception e) {
+            Toast.makeText(context, e.getMessage(), Toast.LENGTH_LONG).show();
+            dlgWaiting.dismiss();
+        }
+    }
+
+    private void loadMembers() {
+        dlgWaiting.show();
+
+        lsrBook = MyApp.db.collection(Constant.KEY_BOOKS).document(MyApp.browsingBook.obtainDocumentId())
                 .addSnapshotListener(new EventListener<DocumentSnapshot>() {
                     @Override
                     public void onEvent(@Nullable DocumentSnapshot documentSnapshot, @Nullable FirebaseFirestoreException e) {
                         Book book = documentSnapshot.toObject(Book.class);
 
-                        List<User> legalMembers = book.getAdminMembers();
-                        legalMembers.addAll(book.getApprovedMembers());
+                        legalMembers.clear();
+                        waitingMembers.clear();
+                        userIds.clear();
 
-                        List<User> waitingMembers = book.getWaitingMembers();
+                        userIds.addAll(book.getAdminMembers());
+                        userIds.addAll(book.getApprovedMembers());
+                        userIds.addAll(book.getWaitingMembers());
 
-                        memberFragments[0].setMembers(legalMembers);
-                        memberFragments[1].setMembers(waitingMembers);
+                        ref = MyApp.db.collection(Constant.KEY_USERS);
 
-                        if (isFirstIn) {
-                            adapter.addFragment(memberFragments[0], String.format("全部（ %d ）", legalMembers.size()));
-                            adapter.addFragment(memberFragments[1], String.format("待批准（ %d ）", waitingMembers.size()));
-                            vpgMember.setAdapter(adapter);
+                        for (String userId : userIds) {
+                            ref.whereEqualTo(Constant.PRO_ID, userId);
+                        }
 
-                            isFirstIn = false;
+                        sortMembers();
+                    }
+                });
+    }
+
+    private void sortMembers() {
+        ref.get()
+                .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+                    @Override
+                    public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                        if (task.isSuccessful()) {
+                            List<DocumentSnapshot> documentSnapshots = task.getResult().getDocuments();
+                            List<User> approvedMembers = new ArrayList<>();
+                            User user;
+
+                            for (int i = 0, len = documentSnapshots.size(); i < len; i++) {
+                                user = documentSnapshots.get(i).toObject(User.class);
+                                user.defineDocumentId(documentSnapshots.get(i).getId());
+
+                                if (MyApp.browsingBook.isAdminUser(user.getId())) {
+                                    legalMembers.add(user);
+                                }
+
+                                if (MyApp.browsingBook.isApprovedUser(user.getId())) {
+                                    approvedMembers.add(user);
+                                }
+
+                                if (MyApp.browsingBook.isWaitingUser(user.getId())) {
+                                    waitingMembers.add(user);
+                                }
+                            }
+
+                            legalMembers.addAll(approvedMembers);
+
+                            showMembers();
                         } else {
-                            adapter.setTitle(0, String.format("全部（ %d ）", legalMembers.size()));
-                            adapter.setTitle(1, String.format("待批准（ %d ）", waitingMembers.size()));
-                            adapter.notifyDataSetChanged();
-                            memberFragments[0].getAdapter().notifyDataSetChanged();
-                            memberFragments[1].getAdapter().notifyDataSetChanged();
+                            Toast.makeText(context, "取得使用者資料失敗", Toast.LENGTH_SHORT).show();
+                            dlgWaiting.dismiss();
                         }
                     }
                 });
+    }
+
+    private void showMembers() {
+        memberFragments[0].setMembers(legalMembers);
+        memberFragments[1].setMembers(waitingMembers);
+
+        if (isFirstIn) {
+            adapter.addFragment(memberFragments[0], String.format("全部（ %d ）", legalMembers.size()));
+            adapter.addFragment(memberFragments[1], String.format("待批准（ %d ）", waitingMembers.size()));
+            vpgMember.setAdapter(adapter);
+
+            isFirstIn = false;
+        } else {
+            adapter.setTitle(0, String.format("全部（ %d ）", legalMembers.size()));
+            adapter.setTitle(1, String.format("待批准（ %d ）", waitingMembers.size()));
+            adapter.notifyDataSetChanged();
+            memberFragments[0].getAdapter().notifyDataSetChanged();
+            memberFragments[1].getAdapter().notifyDataSetChanged();
+        }
+
+        dlgWaiting.dismiss();
     }
 
     @Override

--- a/app/src/main/java/com/vincent/acnt/LoginActivity.java
+++ b/app/src/main/java/com/vincent/acnt/LoginActivity.java
@@ -82,10 +82,9 @@ public class LoginActivity extends RegisterHelper {
                     @Override
                     public void onComplete(@NonNull Task<AuthResult> task) {
                         if (task.isSuccessful()) {
-                            Toast.makeText(context, "Email登入成功", Toast.LENGTH_SHORT).show();
                             prepareLogin();
                         } else {
-                            Toast.makeText(context, "Email登入失敗", Toast.LENGTH_SHORT).show();
+                            Toast.makeText(context, "登入失敗", Toast.LENGTH_SHORT).show();
                             Toast.makeText(context, task.getException().getMessage(), Toast.LENGTH_LONG).show();
                             dlgWaiting.dismiss();
                         }

--- a/app/src/main/java/com/vincent/acnt/adapter/BookGridAdapter.java
+++ b/app/src/main/java/com/vincent/acnt/adapter/BookGridAdapter.java
@@ -1,6 +1,7 @@
 package com.vincent.acnt.adapter;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -55,10 +56,13 @@ public class BookGridAdapter extends BaseAdapter {
 
         if (book.isLegalUser(MyApp.user.getId())) {
             imgBook.setImageResource(R.drawable.img_book_legal);
+            txtBookName.setTextColor(Color.parseColor("#000000"));
         } else if (book.isWaitingUser(MyApp.user.getId())) {
             imgBook.setImageResource(R.drawable.img_book_waiting);
+            txtBookName.setTextColor(Color.parseColor("#808080"));
         } else {
             imgBook.setImageResource(R.drawable.img_book_reject);
+            txtBookName.setTextColor(Color.parseColor("#808080"));
         }
 
         return view;

--- a/app/src/main/java/com/vincent/acnt/adapter/MemberListAdapter.java
+++ b/app/src/main/java/com/vincent/acnt/adapter/MemberListAdapter.java
@@ -1,20 +1,15 @@
 package com.vincent.acnt.adapter;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
-import android.widget.Toast;
 
-import com.google.android.gms.tasks.OnCompleteListener;
-import com.google.android.gms.tasks.Task;
 import com.vincent.acnt.MyApp;
 import com.vincent.acnt.R;
-import com.vincent.acnt.data.Constant;
 import com.vincent.acnt.entity.User;
 
 import java.util.List;
@@ -22,14 +17,11 @@ import java.util.List;
 public class MemberListAdapter extends BaseAdapter {
     private Context context;
     private LayoutInflater layoutInflater;
-    private int type;
-    public int clickIndex;
     private List<User> members;
 
-    public MemberListAdapter(Context context, int type, List<User> members) {
+    public MemberListAdapter(Context context, List<User> members) {
         this.context = context;
         this.layoutInflater = LayoutInflater.from(context);
-        this.type = type;
         this.members = members;
     }
 
@@ -72,75 +64,6 @@ public class MemberListAdapter extends BaseAdapter {
 
     public void setMembers(List<User> members) {
         this.members = members;
-    }
-
-    public void approveUser(final User user) {
-        MyApp.browsingBook.removeWaitingMember(user.getId());
-        MyApp.browsingBook.getApprovedMembers().add(user);
-
-        MyApp.db.collection(Constant.KEY_BOOKS).document(MyApp.browsingBook.obtainDocumentId())
-                .set(MyApp.browsingBook)
-                .addOnCompleteListener(new OnCompleteListener<Void>() {
-                    @Override
-                    public void onComplete(@NonNull Task<Void> task) {
-                        Toast.makeText(context, "已加入" + user.getName(), Toast.LENGTH_SHORT).show();
-                    }
-                });
-    }
-
-    public void rejectUser(final User user) {
-        MyApp.browsingBook.removeWaitingMember(user.getId());
-
-        MyApp.db.collection(Constant.KEY_BOOKS).document(MyApp.browsingBook.obtainDocumentId())
-                .set(MyApp.browsingBook)
-                .addOnCompleteListener(new OnCompleteListener<Void>() {
-                    @Override
-                    public void onComplete(@NonNull Task<Void> task) {
-                        Toast.makeText(context, "已拒絕" + user.getName(), Toast.LENGTH_SHORT).show();
-                    }
-                });
-    }
-
-    public void upgradeUser(final User user) {
-        MyApp.browsingBook.removeApprovedMember(user.getId());
-        MyApp.browsingBook.addAdminMember(user);
-
-        MyApp.db.collection(Constant.KEY_BOOKS).document(MyApp.browsingBook.obtainDocumentId())
-                .set(MyApp.browsingBook)
-                .addOnCompleteListener(new OnCompleteListener<Void>() {
-                    @Override
-                    public void onComplete(@NonNull Task<Void> task) {
-                        Toast.makeText(context, "已給予" + user.getName() + "管理員身份", Toast.LENGTH_SHORT).show();
-                    }
-                });
-    }
-
-    public void degradeUser(final User user) {
-        MyApp.browsingBook.removeAdminMember(user.getId());
-        MyApp.browsingBook.addApprovedMember(user);
-
-        MyApp.db.collection(Constant.KEY_BOOKS).document(MyApp.browsingBook.obtainDocumentId())
-                .set(MyApp.browsingBook)
-                .addOnCompleteListener(new OnCompleteListener<Void>() {
-                    @Override
-                    public void onComplete(@NonNull Task<Void> task) {
-                        Toast.makeText(context, "已移除"  + user.getName() + "的管理員身份", Toast.LENGTH_SHORT).show();
-                    }
-                });
-    }
-
-    public void removeUser(final User user) {
-        MyApp.browsingBook.removeApprovedMember(user.getId());
-        MyApp.browsingBook.removeAdminMember(user.getId());
-
-        MyApp.db.collection(Constant.KEY_BOOKS).document(MyApp.browsingBook.obtainDocumentId())
-                .set(MyApp.browsingBook)
-                .addOnCompleteListener(new OnCompleteListener<Void>() {
-                    @Override
-                    public void onComplete(@NonNull Task<Void> task) {
-                        Toast.makeText(context, "已移除" + user.getName(), Toast.LENGTH_SHORT).show();
-                    }
-                });
     }
 
 }

--- a/app/src/main/java/com/vincent/acnt/entity/Book.java
+++ b/app/src/main/java/com/vincent/acnt/entity/Book.java
@@ -7,7 +7,10 @@ import java.util.List;
 public class Book implements Serializable {
     private String id;
     private String name, creator;
-    private List<User> approvedMembers = new ArrayList<>(), waitingMembers = new ArrayList<>(), adminMembers = new ArrayList<>();
+    private List<String> approvedMembers = new ArrayList<>(),
+            waitingMembers = new ArrayList<>(),
+            adminMembers = new ArrayList<>();
+    
     private String documentId;
 
     public Book() {
@@ -38,11 +41,11 @@ public class Book implements Serializable {
         this.creator = creator;
     }
 
-    public List<User> getApprovedMembers() {
+    public List<String> getApprovedMembers() {
         return approvedMembers;
     }
 
-    public void setApprovedMembers(List<User> approvedMembers) {
+    public void setApprovedMembers(List<String> approvedMembers) {
         if (approvedMembers == null) {
             approvedMembers = new ArrayList<>();
         }
@@ -50,40 +53,40 @@ public class Book implements Serializable {
         this.approvedMembers = approvedMembers;
     }
 
-    public List<User> getWaitingMembers() {
+    public List<String> getWaitingMembers() {
         return waitingMembers;
     }
 
-    public void setWaitingMembers(List<User> waitingMembers) {
+    public void setWaitingMembers(List<String> waitingMembers) {
         if (waitingMembers == null) {
             waitingMembers = new ArrayList<>();
         }
         this.waitingMembers = waitingMembers;
     }
 
-    public List<User> getAdminMembers() {
+    public List<String> getAdminMembers() {
         return adminMembers;
     }
 
-    public void setAdminMembers(List<User> adminMembers) {
+    public void setAdminMembers(List<String> adminMembers) {
         this.adminMembers = adminMembers;
     }
 
-    public void addApprovedMember(User member) {
+    public void addApprovedMember(String member) {
         if (approvedMembers == null) {
             approvedMembers = new ArrayList<>();
         }
         approvedMembers.add(member);
     }
 
-    public void addWaitingMember(User member) {
+    public void addWaitingMember(String member) {
         if (waitingMembers == null) {
             waitingMembers = new ArrayList<>();
         }
         waitingMembers.add(member);
     }
 
-    public void addAdminMember(User member) {
+    public void addAdminMember(String member) {
         if (adminMembers == null) {
             adminMembers = new ArrayList<>();
         }
@@ -91,30 +94,15 @@ public class Book implements Serializable {
     }
 
     public void removeApprovedMember(String userId) {
-        for (int i = 0, len = approvedMembers.size(); i < len; i++) {
-            if (approvedMembers.get(i).getId().equals(userId)) {
-                approvedMembers.remove(i);
-                return;
-            }
-        }
+        approvedMembers.remove(userId);
     }
 
     public void removeWaitingMember(String userId) {
-        for (int i = 0, len = waitingMembers.size(); i < len; i++) {
-            if (waitingMembers.get(i).getId().equals(userId)) {
-                waitingMembers.remove(i);
-                return;
-            }
-        }
+        waitingMembers.remove(userId);
     }
 
     public void removeAdminMember(String userId) {
-        for (int i = 0, len = adminMembers.size(); i < len; i++) {
-            if (adminMembers.get(i).getId().equals(userId)) {
-                adminMembers.remove(i);
-                return;
-            }
-        }
+        adminMembers.remove(userId);
     }
 
     public String obtainDocumentId() {
@@ -125,33 +113,20 @@ public class Book implements Serializable {
         this.documentId = documentId;
     }
 
-    public boolean isLegalUser(String userId) {
-        for (int i = 0, len = approvedMembers.size(); i < len; i++) {
-            if (approvedMembers.get(i).getId().equals(userId)) {
-                return true;
-            }
-        }
+    public boolean isAdminUser(String userId) {
+        return adminMembers.contains(userId);
+    }
 
-        return isAdminUser(userId);
+    public boolean isApprovedUser(String userId) {
+        return approvedMembers.contains(userId);
     }
 
     public boolean isWaitingUser(String userId) {
-        for (int i = 0, len = waitingMembers.size(); i < len; i++) {
-            if (waitingMembers.get(i).getId().equals(userId)) {
-                return true;
-            }
-        }
-
-        return false;
+        return waitingMembers.contains(userId);
     }
 
-    public boolean isAdminUser(String userId) {
-        for (int i = 0, len = adminMembers.size(); i < len; i++) {
-            if (adminMembers.get(i).getId().equals(userId)) {
-                return true;
-            }
-        }
-
-        return false;
+    public boolean isLegalUser(String userId) {
+        return isApprovedUser(userId) || isAdminUser(userId);
     }
+
 }

--- a/app/src/main/res/layout/grd_book.xml
+++ b/app/src/main/res/layout/grd_book.xml
@@ -20,7 +20,6 @@
         android:layout_marginTop="5dp"
         android:paddingBottom="7.5dp"
         android:textSize="18sp"
-        android:textColor="#000000"
         android:maxLines="1"/>
 
 </LinearLayout>


### PR DESCRIPTION
對Firestore查詢時，有時會使用whereEqualTo方法來附加條件。若對CollectionReference使用多次whereEqualTo，則欄位名稱相同的部份會變成「or運算」，因此可藉由給定一個List來查詢出所有使用者，如：collectionReference.whereEqualTo("id", "userId1").whereEqualTo("id", "userId2")。